### PR TITLE
Fix links for dependabot pr's

### DIFF
--- a/source/documentation/runbooks/011-support-duties.html.md.erb
+++ b/source/documentation/runbooks/011-support-duties.html.md.erb
@@ -21,8 +21,8 @@ Support is provided on weekdays between 9am - 5pm.
     - [Teams -  ask-data-catalogue] (https://teams.microsoft.com/l/channel/19%3Abb91d2a728a54472a41629ee6f2908ea%40thread.tacv2/Ask%20Data%20Catalogue?groupId=f6c3cb3b-591c-4e47-9997-25b6dc9bf5b6&tenantId=c6874728-71e6-41fe-a9e1-2e8c36776ad8)
 
 - Review & merge dependabot pull requests
-    - [Project backlog](https://github.com/orgs/ministryofjustice/projects/57/views/25?visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C%22Labels%22%2C69173332%5D&filterQuery=-status%3ADone+label%3Adependencies)
-    - [Open pull requests](https://github.com/ministryofjustice/find-moj-data/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies)
+    - [Fmd open pull requests](https://github.com/ministryofjustice/find-moj-data/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies)
+    - [Datahub open pull requests] (https://github.com/ministryofjustice/data-catalogue/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies)
 
 - Action deploy to production tickets
-    - [Project backlog] (https://github.com/orgs/ministryofjustice/projects/57/views/25?filterQuery=-status%3ADone+label%3A%22push+to+prod%22+)
+    - Review the current sprint & backlog for any deploy to production tickets


### PR DESCRIPTION
- Removes link to the backlog view which can change
- adds link to the data catalogue repo for open dependabot pr's