### PR TITLE
Update review dates for

### DIFF
--- a/source/documentation/runbooks/011-graphql-performance.html.md.erb
+++ b/source/documentation/runbooks/011-graphql-performance.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#data-catalogue"
 title: Analyse GraphQL performance
-last_reviewed_on: 2024-12-19
+last_reviewed_on: 2025-06-20
 review_in: 6 months
 ---
 

--- a/source/documentation/runbooks/012-support-duties.html.md.erb
+++ b/source/documentation/runbooks/012-support-duties.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#data-catalogue"
 title: Daily support
-last_reviewed_on: 2024-12-19
+last_reviewed_on: 2025-06-20
 review_in: 6 months
 ---
 

--- a/source/documentation/runbooks/015-dashboard.html.md.erb
+++ b/source/documentation/runbooks/015-dashboard.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#data-catalogue"
 title: Metadata dashboard
-last_reviewed_on: 2024-12-11
+last_reviewed_on: 2025-06-20
 review_in: 6 months
 ---
 # <%= current_page.data.title %>

--- a/source/documentation/ways-of-working/index.html.md.erb
+++ b/source/documentation/ways-of-working/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#data-catalogue"
 title: Ways of working
-last_reviewed_on: 2024-12-18
+last_reviewed_on: 2025-06-20
 review_in: 6 months
 ---
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#data-catalogue"
 title: MoJ Data Catalogue Runbooks
-last_reviewed_on: 2024-12-13
+last_reviewed_on: 2025-06-20
 review_in: 6 months
 weight: 0
 ---


### PR DESCRIPTION
Metadata dashboard (9 days ago)
- MoJ Data Catalogue Runbooks (7 days ago)
- Ways of working (2 days ago)
- Analyse GraphQL performance (yesterday)
- Daily support (yesterday

Adjusted the  dates to reflect the latest review. Files are now set to be reviewed again in six months.